### PR TITLE
android:nameの指定と一部の自動DIへの切り替え

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <application
+        android:name=".application.NITechVacancyViewerApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/application/di/RepositoryModule.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/application/di/RepositoryModule.kt
@@ -1,9 +1,17 @@
 package com.punyo.nitechvacancyviewer.application.di
 
+import com.punyo.nitechvacancyviewer.data.building.BuildingRepository
+import com.punyo.nitechvacancyviewer.data.building.BuildingRepositoryImpl
+import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class RepositoryModule
+abstract class RepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindBuildingRepository(buildingRepositoryImpl: BuildingRepositoryImpl): BuildingRepository
+}

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/application/di/SourceModule.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/application/di/SourceModule.kt
@@ -1,6 +1,6 @@
 package com.punyo.nitechvacancyviewer.application.di
 
-import com.punyo.nitechvacancyviewer.data.building.source.BuildingLocalDatasource
+import com.punyo.nitechvacancyviewer.data.building.source.BuildingLocalDataSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -12,5 +12,5 @@ import javax.inject.Singleton
 object SourceModule {
     @Provides
     @Singleton
-    fun provideBuildingLocalDataSource(): BuildingLocalDatasource = BuildingLocalDatasource()
+    fun provideBuildingLocalDataSource(): BuildingLocalDataSource = BuildingLocalDataSource()
 }

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/application/di/SourceModule.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/application/di/SourceModule.kt
@@ -1,9 +1,16 @@
 package com.punyo.nitechvacancyviewer.application.di
 
+import com.punyo.nitechvacancyviewer.data.building.source.BuildingLocalDatasource
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object SourceModule
+object SourceModule {
+    @Provides
+    @Singleton
+    fun provideBuildingLocalDataSource(): BuildingLocalDatasource = BuildingLocalDatasource()
+}

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/building/BuildingRepository.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/building/BuildingRepository.kt
@@ -1,12 +1,8 @@
 package com.punyo.nitechvacancyviewer.data.building
 
 import com.punyo.nitechvacancyviewer.data.building.model.Building
-import com.punyo.nitechvacancyviewer.data.building.source.BuildingLocalDatasource
 import java.io.InputStream
 
-class BuildingRepository(private val buildingLocalDatasource: BuildingLocalDatasource) {
-    suspend fun getBuildings(inputStream: InputStream): Array<Building> {
-        val buildingsDataModel = buildingLocalDatasource.getBuildingsDataFromJson(inputStream)
-        return buildingsDataModel.buildingsData
-    }
+interface BuildingRepository {
+    suspend fun getBuildings(inputStream: InputStream): Array<Building>
 }

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/building/BuildingRepositoryImpl.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/building/BuildingRepositoryImpl.kt
@@ -1,14 +1,14 @@
 package com.punyo.nitechvacancyviewer.data.building
 
 import com.punyo.nitechvacancyviewer.data.building.model.Building
-import com.punyo.nitechvacancyviewer.data.building.source.BuildingLocalDatasource
+import com.punyo.nitechvacancyviewer.data.building.source.BuildingLocalDataSource
 import java.io.InputStream
 import javax.inject.Inject
 
 class BuildingRepositoryImpl
     @Inject
     constructor(
-        private val buildingLocalDatasource: BuildingLocalDatasource,
+        private val buildingLocalDatasource: BuildingLocalDataSource,
     ) : BuildingRepository {
         override suspend fun getBuildings(inputStream: InputStream): Array<Building> {
             val buildingsDataModel = buildingLocalDatasource.getBuildingsDataFromJson(inputStream)

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/building/BuildingRepositoryImpl.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/building/BuildingRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.punyo.nitechvacancyviewer.data.building
+
+import com.punyo.nitechvacancyviewer.data.building.model.Building
+import com.punyo.nitechvacancyviewer.data.building.source.BuildingLocalDatasource
+import java.io.InputStream
+import javax.inject.Inject
+
+class BuildingRepositoryImpl
+    @Inject
+    constructor(
+        private val buildingLocalDatasource: BuildingLocalDatasource,
+    ) : BuildingRepository {
+        override suspend fun getBuildings(inputStream: InputStream): Array<Building> {
+            val buildingsDataModel = buildingLocalDatasource.getBuildingsDataFromJson(inputStream)
+            return buildingsDataModel.buildingsData
+        }
+    }

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/building/source/BuildingLocalDataSource.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/building/source/BuildingLocalDataSource.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.withContext
 import java.io.BufferedReader
 import java.io.InputStream
 
-class BuildingLocalDatasource {
+class BuildingLocalDataSource {
     suspend fun getBuildingsDataFromJson(inputStream: InputStream): BuildingsDataModel =
         withContext(Dispatchers.IO) {
             val bufferedReader = BufferedReader(inputStream.reader())

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/ui/component/VacancyComponent.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/ui/component/VacancyComponent.kt
@@ -29,13 +29,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.punyo.nitechvacancyviewer.R
 import com.punyo.nitechvacancyviewer.application.GsonInstance
-import com.punyo.nitechvacancyviewer.data.building.BuildingRepository
-import com.punyo.nitechvacancyviewer.data.building.source.BuildingLocalDatasource
 import com.punyo.nitechvacancyviewer.data.room.model.Room
 import com.punyo.nitechvacancyviewer.ui.model.VacancyComponentViewModel
 import java.time.LocalDateTime
@@ -50,13 +48,7 @@ fun VacancyComponent(
     isRefreshVacancy: Boolean,
     lastVacancyRefreshTimeString: String,
     roomsData: Array<Room>,
-    viewModel: VacancyComponentViewModel =
-        viewModel(
-            factory =
-                VacancyComponentViewModel.Factory(
-                    buildingRepository = BuildingRepository(BuildingLocalDatasource()),
-                ),
-        ),
+    viewModel: VacancyComponentViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val currentState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/ui/model/VacancyComponentViewModel.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/ui/model/VacancyComponentViewModel.kt
@@ -1,53 +1,49 @@
 package com.punyo.nitechvacancyviewer.ui.model
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import com.punyo.nitechvacancyviewer.data.building.BuildingRepository
 import com.punyo.nitechvacancyviewer.data.building.model.Building
 import com.punyo.nitechvacancyviewer.data.room.model.Room
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.io.InputStream
 import java.time.LocalDateTime
+import javax.inject.Inject
 
-class VacancyComponentViewModel(
-    private val buildingRepository: BuildingRepository,
-) : ViewModel() {
-    private val state = MutableStateFlow(VacancyComponentUiState())
-    val uiState: StateFlow<VacancyComponentUiState> = state.asStateFlow()
+@HiltViewModel
+class VacancyComponentViewModel
+    @Inject
+    constructor(
+        private val buildingRepository: BuildingRepository,
+    ) : ViewModel() {
+        private val state = MutableStateFlow(VacancyComponentUiState())
+        val uiState: StateFlow<VacancyComponentUiState> = state.asStateFlow()
 
-    fun getNumberOfVacantRoom(roomsData: Array<Room>, time: LocalDateTime): UInt {
-        return roomsData.filter { room ->
-            !room.eventsInfo.any { eventTime ->
-                time.isAfter(eventTime.start) && time.isBefore(eventTime.end)
-            }
-        }.size.toUInt()
-    }
+        fun getNumberOfVacantRoom(
+            roomsData: Array<Room>,
+            time: LocalDateTime,
+        ): UInt =
+            roomsData
+                .filter { room ->
+                    !room.eventsInfo.any { eventTime ->
+                        time.isAfter(eventTime.start) && time.isBefore(eventTime.end)
+                    }
+                }.size
+                .toUInt()
 
-    suspend fun loadBuildings(inputStream: InputStream) {
-        val buildings = buildingRepository.getBuildings(inputStream)
-        state.value = state.value.copy(buildings = buildings)
-    }
-
-    class Factory(private val buildingRepository: BuildingRepository) :
-        ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(VacancyComponentViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return VacancyComponentViewModel(buildingRepository) as T
-            }
-            throw IllegalArgumentException("Unknown ViewModel class")
+        suspend fun loadBuildings(inputStream: InputStream) {
+            val buildings = buildingRepository.getBuildings(inputStream)
+            state.value = state.value.copy(buildings = buildings)
         }
     }
 
-}
-
 data class VacancyComponentUiState(
-    val buildings: Array<Building>? = null
+    val buildings: Array<Building>? = null,
 )
 
 enum class RoomVacancyStatus {
     VACANT,
-    OCCUPY
+    OCCUPY,
 }


### PR DESCRIPTION
# 概要
android:nameの指定を行い、一部を自動DIに切り替えた。
また、BuildingLocalDatasourceをBuildingLocalDataSourceにリネームすることでデータソースの表記を"DataSource"に統一した。

# 細かな変更点
- android:nameの指定
- BuildingRepositoryとそれに依存するViewModelを手動DIから自動DIに切り替え
- BuildingLocalDatasourceをBuildingLocalDataSourceにリネーム

# 既存の箇所への影響範囲
既存機能への影響なし