### PR TITLE
fix: 時刻パースエラー時のクラッシュ修正とnull安全対応 (v1.6.1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.punyo.nitechvacancyviewer"
         minSdk = 26
         targetSdk = 35
-        versionCode = 12
-        versionName = "1.6.1"
+        versionCode = 13
+        versionName = "1.6.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.punyo.nitechvacancyviewer"
         minSdk = 26
         targetSdk = 35
-        versionCode = 11
-        versionName = "1.6"
+        versionCode = 12
+        versionName = "1.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/application/GsonInstance.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/application/GsonInstance.kt
@@ -12,6 +12,7 @@ import java.time.LocalDateTime
 object GsonInstance {
     val gson: Gson =
         GsonBuilder()
+            .serializeNulls()
             .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeSerializer())
             .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeDeserializer())
             .create()

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/model/RoomsDataModel.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/model/RoomsDataModel.kt
@@ -26,12 +26,14 @@ data class Room(
 )
 
 data class EventInfo(
-    val start: LocalDateTime,
-    val end: LocalDateTime,
+    val start: LocalDateTime?,
+    val end: LocalDateTime?,
     val eventDescription: String = "",
 ) {
     fun getStartAndEndString(): String {
         val formatter = CommonDateTimeFormater.formatter
-        return "${start.format(formatter)} ～ ${end.format(formatter)}"
+        val startStr = start?.format(formatter) ?: "不明"
+        val endStr = end?.format(formatter) ?: "不明"
+        return "$startStr ～ $endStr"
     }
 }

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/source/RoomLocalDataSource.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/source/RoomLocalDataSource.kt
@@ -10,6 +10,7 @@ import com.punyo.nitechvacancyviewer.data.room.model.Room
 import com.punyo.nitechvacancyviewer.data.room.model.RoomsDataModel
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
+import java.time.DateTimeException
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -142,8 +143,8 @@ class RoomLocalDataSource {
                 val eventTimes = eventStrings[0].split("-")
                 events.add(
                     EventInfo(
-                        start = parseTime(eventTimes[0]).plusDays(row.toLong()),
-                        end = parseTime(eventTimes[1]).plusDays(row.toLong()),
+                        start = parseTime(eventTimes[0])?.plusDays(row.toLong()),
+                        end = parseTime(eventTimes[1])?.plusDays(row.toLong()),
                         eventDescription = eventStrings[1],
                     ),
                 )
@@ -153,12 +154,17 @@ class RoomLocalDataSource {
         return RoomsDataModel(rooms.toTypedArray(), earliestDayOfData.plusDays(row.toLong()))
     }
 
-    private fun parseTime(time: String): LocalDateTime {
-        val timeArray = time.split(":")
-        return LocalDateTime
-            .now()
-            .withHour(timeArray[0].toInt())
-            .withMinute(timeArray[1].toInt())
-            .withSecond(0)
-    }
+    private fun parseTime(time: String): LocalDateTime? =
+        try {
+            val timeArray = time.split(":")
+            LocalDateTime
+                .now()
+                .withHour(timeArray[0].toInt())
+                .withMinute(timeArray[1].toInt())
+                .withSecond(0)
+        } catch (e: NumberFormatException) {
+            null
+        } catch (e: DateTimeException) {
+            null
+        }
 }

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/source/RoomLocalDataSource.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/source/RoomLocalDataSource.kt
@@ -156,17 +156,17 @@ class RoomLocalDataSource {
 
     private fun parseTime(time: String): LocalDateTime? =
         try {
-             when(time) {
-                "<<" ->  LocalDateTime.now().withHour(0).withMinute(0).withSecond(0)
-                ">>" ->  LocalDateTime.now().withHour(23).withMinute(59).withSecond(0)
-                 else ->{
-                     val timeArray = time.split(":")
-                     LocalDateTime
-                         .now()
-                         .withHour(timeArray[0].toInt())
-                         .withMinute(timeArray[1].toInt())
-                         .withSecond(0)
-                 }
+            when (time) {
+                "<<" -> LocalDateTime.now().withHour(0).withMinute(0).withSecond(0)
+                ">>" -> LocalDateTime.now().withHour(23).withMinute(59).withSecond(0)
+                else -> {
+                    val timeArray = time.split(":")
+                    LocalDateTime
+                        .now()
+                        .withHour(timeArray[0].toInt())
+                        .withMinute(timeArray[1].toInt())
+                        .withSecond(0)
+                }
             }
         } catch (_: NumberFormatException) {
             null

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/source/RoomLocalDataSource.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/source/RoomLocalDataSource.kt
@@ -156,15 +156,21 @@ class RoomLocalDataSource {
 
     private fun parseTime(time: String): LocalDateTime? =
         try {
-            val timeArray = time.split(":")
-            LocalDateTime
-                .now()
-                .withHour(timeArray[0].toInt())
-                .withMinute(timeArray[1].toInt())
-                .withSecond(0)
-        } catch (e: NumberFormatException) {
+             when(time) {
+                "<<" -> return LocalDateTime.now().withHour(0).withMinute(0).withSecond(0)
+                ">>" -> return LocalDateTime.now().withHour(23).withMinute(59).withSecond(0)
+                 else ->{
+                     val timeArray = time.split(":")
+                     LocalDateTime
+                         .now()
+                         .withHour(timeArray[0].toInt())
+                         .withMinute(timeArray[1].toInt())
+                         .withSecond(0)
+                 }
+            }
+        } catch (_: NumberFormatException) {
             null
-        } catch (e: DateTimeException) {
+        } catch (_: DateTimeException) {
             null
         }
 }

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/source/RoomLocalDataSource.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/room/source/RoomLocalDataSource.kt
@@ -157,8 +157,8 @@ class RoomLocalDataSource {
     private fun parseTime(time: String): LocalDateTime? =
         try {
              when(time) {
-                "<<" -> return LocalDateTime.now().withHour(0).withMinute(0).withSecond(0)
-                ">>" -> return LocalDateTime.now().withHour(23).withMinute(59).withSecond(0)
+                "<<" ->  LocalDateTime.now().withHour(0).withMinute(0).withSecond(0)
+                ">>" ->  LocalDateTime.now().withHour(23).withMinute(59).withSecond(0)
                  else ->{
                      val timeArray = time.split(":")
                      LocalDateTime

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/ui/buildingvacancy/BuildingVacancyScreenViewModel.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/ui/buildingvacancy/BuildingVacancyScreenViewModel.kt
@@ -28,6 +28,7 @@ constructor(
         roomsData
             .filter { room ->
                 !room.eventsInfo.any { eventTime ->
+                    if (eventTime.start == null || eventTime.end == null) return@any true
                     time.isAfter(eventTime.start) && time.isBefore(eventTime.end)
                 }
             }.size

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/ui/roomreservation/RoomReservationViewModel.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/ui/roomreservation/RoomReservationViewModel.kt
@@ -4,20 +4,29 @@ import androidx.lifecycle.ViewModel
 import com.punyo.nitechvacancyviewer.data.room.model.Room
 import java.time.LocalDateTime
 
+sealed class NextEventResult {
+    data class Known(val minutes: Int) : NextEventResult()
+    object Unknown : NextEventResult()
+    object None : NextEventResult()
+}
+
 class RoomReservationViewModel : ViewModel() {
-    fun getMinutesUntilNextEvent(room: Room): Int? {
+    fun getMinutesUntilNextEvent(room: Room): NextEventResult {
         val now = LocalDateTime.now()
+        val hasUnknownStartEvent = room.eventsInfo.any { it.start == null }
         val nextEvent =
             room.eventsInfo
                 .filter { event ->
-                    now.isBefore(event.start)
-                }.minByOrNull { it.start }
-        return if (nextEvent != null) {
-            val diff =
-                nextEvent.start.toLocalTime().toSecondOfDay() - now.toLocalTime().toSecondOfDay()
-            diff / 60
-        } else {
-            null
+                    event.start != null && now.isBefore(event.start)
+                }.minByOrNull { it.start!! }
+        return when {
+            nextEvent != null -> {
+                val diff =
+                    nextEvent.start!!.toLocalTime().toSecondOfDay() - now.toLocalTime().toSecondOfDay()
+                NextEventResult.Known(diff / 60)
+            }
+            hasUnknownStartEvent -> NextEventResult.Unknown
+            else -> NextEventResult.None
         }
     }
 }

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/ui/roomvacancy/RoomVacancyScreen.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/ui/roomvacancy/RoomVacancyScreen.kt
@@ -34,6 +34,31 @@ fun RoomVacancyScreen(
     rooms: Array<Room>,
     roomVacancyScreenViewModel: RoomVacancyScreenViewModel = viewModel(),
 ) {
+    val currentTime = LocalDateTime.now()
+
+    RoomVacancyScreenInternal(
+        buildingName = buildingName,
+        rooms = rooms,
+        currentTime = currentTime,
+        onBackPressed = onBackPressed,
+        getRoomVacancy = { room, time ->
+            roomVacancyScreenViewModel.getRoomVacancy(room, time)
+        },
+        getCurrentEvent = { room, time ->
+            roomVacancyScreenViewModel.getCurrentEvent(room, time)
+        },
+    )
+}
+
+@Composable
+private fun RoomVacancyScreenInternal(
+    buildingName: String,
+    rooms: Array<Room>,
+    currentTime: LocalDateTime,
+    onBackPressed: () -> Unit = {},
+    getRoomVacancy: (Room, LocalDateTime) -> RoomVacancyStatus = { _, _ -> RoomVacancyStatus.VACANT },
+    getCurrentEvent: (Room, LocalDateTime) -> EventInfo? = { _, _ -> null },
+) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
@@ -50,8 +75,7 @@ fun RoomVacancyScreen(
                 .verticalScroll(rememberScrollState()),
         ) {
             rooms.forEachIndexed { index, room ->
-                val roomVacancyStatus =
-                    roomVacancyScreenViewModel.getRoomVacancy(room, LocalDateTime.now())
+                val roomVacancyStatus = getRoomVacancy(room, currentTime)
                 ListItem(
                     headlineContent = {
                         Text(
@@ -84,11 +108,7 @@ fun RoomVacancyScreen(
                                 RoomVacancyStatus.VACANT -> stringResource(id = R.string.UI_LISTITEM_TEXT_VACANT)
                                 RoomVacancyStatus.OCCUPY ->
                                     stringResource(id = R.string.UI_LISTITEM_TEXT_OCCUPY).format(
-                                        roomVacancyScreenViewModel
-                                            .getCurrentEvent(
-                                                room,
-                                                LocalDateTime.now(),
-                                            )?.eventDescription ?: "",
+                                        getCurrentEvent(room, currentTime)?.eventDescription ?: "",
                                     )
                             },
                         )
@@ -103,33 +123,50 @@ fun RoomVacancyScreen(
 
 @Preview(showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_NO)
 @Composable
-fun RoomVacancyScreenLightModePreview() {
-    AppTheme {
-        RoomVacancyScreen(
-            "建物の名称",
-            rooms =
-            arrayOf(
-                Room(
-                    "部屋1",
-                    arrayOf(
-                        EventInfo(
-                            LocalDateTime.now().minusHours(1),
-                            LocalDateTime.now().plusHours(1),
-                            "数理情報概論",
-                        ),
-                    ),
-                ),
-                Room(
-                    "部屋2",
-                    arrayOf(
-                        EventInfo(
-                            LocalDateTime.now().plusHours(1),
-                            LocalDateTime.now().plusHours(2),
-                            "イベント2",
-                        ),
+private fun RoomVacancyScreen() {
+    val currentTime = LocalDateTime.now()
+    val rooms =
+        arrayOf(
+            Room(
+                "部屋1",
+                arrayOf(
+                    EventInfo(
+                        currentTime.minusHours(1),
+                        currentTime.plusHours(1),
+                        "数理情報概論",
                     ),
                 ),
             ),
+            Room(
+                "部屋2",
+                arrayOf(
+                    EventInfo(
+                        currentTime.plusHours(1),
+                        currentTime.plusHours(2),
+                        "イベント2",
+                    ),
+                ),
+            ),
+        )
+    AppTheme {
+        RoomVacancyScreenInternal(
+            buildingName = "建物の名称",
+            rooms = rooms,
+            currentTime = currentTime,
+            getRoomVacancy = { room, time ->
+                val isTimeWithinEvent =
+                    room.eventsInfo.any { eventTime ->
+                        if (eventTime.start == null || eventTime.end == null) return@any true
+                        time.isAfter(eventTime.start) && time.isBefore(eventTime.end)
+                    }
+                if (isTimeWithinEvent) RoomVacancyStatus.OCCUPY else RoomVacancyStatus.VACANT
+            },
+            getCurrentEvent = { room, time ->
+                room.eventsInfo.find {
+                    it.start != null && it.end != null &&
+                        time.isAfter(it.start) && time.isBefore(it.end)
+                } ?: room.eventsInfo.find { it.start == null || it.end == null }
+            },
         )
     }
 }

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/ui/roomvacancy/RoomVacancyScreenViewModel.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/ui/roomvacancy/RoomVacancyScreenViewModel.kt
@@ -13,6 +13,7 @@ class RoomVacancyScreenViewModel : ViewModel() {
     ): RoomVacancyStatus {
         val isTimeWithinEvent =
             room.eventsInfo.any { eventTime ->
+                if (eventTime.start == null || eventTime.end == null) return@any true
                 time.isAfter(eventTime.start) && time.isBefore(eventTime.end)
             }
         return if (isTimeWithinEvent) {
@@ -26,7 +27,8 @@ class RoomVacancyScreenViewModel : ViewModel() {
         room: Room,
         time: LocalDateTime,
     ): EventInfo? =
-        room.eventsInfo.find { eventTime ->
-            time.isAfter(eventTime.start) && time.isBefore(eventTime.end)
-        }
+        room.eventsInfo.find {
+            it.start != null && it.end != null &&
+                time.isAfter(it.start) && time.isBefore(it.end)
+        } ?: room.eventsInfo.find { it.start == null || it.end == null }
 }


### PR DESCRIPTION
# 概要

時刻パース処理において、不正な入力（`<<`・`>>`等）が与えられた際にクラッシュが発生していた問題を修正した。
`parseTime` 関数の戻り値を `LocalDateTime?` に変更し、パース失敗時は `null` を返すよう修正した。
また、`EventInfo` の `start`・`end` フィールドをnullableにし、各ViewModelでnullチェックを追加した。
あわせてバージョンコードを12、バージョン名を1.6.1に更新した。

# 細かな変更点

- **`RoomLocalDataSource`**: `parseTime` の戻り値を `LocalDateTime?` に変更し、`DateTimeException` 等の例外をキャッチしてnullを返すよう修正した
- **`RoomsDataModel` (`EventInfo`)**: `start`・`end` フィールドを `LocalDateTime?` に変更した
- **`GsonInstance`**: `serializeNulls()` を追加し、nullフィールドもシリアライズされるよう変更した
- **`RoomReservationViewModel`**: `getMinutesUntilNextEvent` の戻り値を `Int?` から sealed class `NextEventResult`（`Known`・`Unknown`・`None`）に変更し、時刻不明な場合を明示的に表現できるようにした
- **`BuildingVacancyScreenViewModel`**: `start`・`end` がnullのイベントを「使用中」として扱うnullチェックを追加した
- **`RoomVacancyScreenViewModel`**: `getRoomVacancy`・`getCurrentEvent` において `start`・`end` のnullチェックを追加した。また `getCurrentEvent` は時刻不明なイベントもフォールバックとして返すよう変更した
- **`RoomVacancyScreen`**: テスト容易性向上のため `getRoomVacancy`・`getCurrentEvent` をパラメータとして受け取るよう `RoomVacancyScreenInternal` に抽出し、プレビュー用のデータも整備した
- **`app/build.gradle.kts`**: `versionCode` を11→12、`versionName` を1.6→1.6.1に更新した

# 既存の箇所への影響範囲

- `EventInfo.start`・`EventInfo.end` がnullableになったため、これらのフィールドを参照している箇所はすべてnullチェックが必要となる。本PRで影響範囲内の全ファイル（`BuildingVacancyScreenViewModel`・`RoomVacancyScreenViewModel`）を修正済みである
- `RoomReservationViewModel.getMinutesUntilNextEvent` の戻り値型が変更されたため、呼び出し元での対応が必要となる