### PR TITLE
fix: 端末移行等でmaster keyを失った場合の認証情報の復号失敗に対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,21 +7,18 @@ captures
 **/local.properties
 
 # IntelliJ .idea folder
-.idea/workspace.xml
-.idea/libraries
-.idea/caches
-.idea/navEditor.xml
-.idea/tasks.xml
-.idea/modules.xml
-.idea/compiler.xml
-.idea/jarRepositories.xml
-.idea/deploymentTargetDropDown.xml
-.idea/deploymentTargetSelector.xml
-.idea/misc.xml
-.idea/androidTestResultsUserPreferences.xml
-.idea/inspectionProfiles
-.idea/vcs.xml
-.idea/AndroidProjectSystem.xml
+.idea/*
+!.idea/externalDependencies.xml
+!.idea/copyright
+!.idea/codeInsightSettings.xml
+!/.idea/codeStyles
+/.idea/codeStyles/*
+!/.idea/codeStyles/Project.xml
+!/.idea/codeStyles/codeStyleConfig.xml
+!/.idea/icon*.svg
+!/.idea/dictionaries
+/.idea/dictionaries/*
+!/.idea/dictionaries/dictionary.xml
 
 # Ignore all auto-generated configs except for app.xml. It's needed as template for the build
 .idea/runConfigurations.xml
@@ -55,3 +52,5 @@ site
 
 #TFLite
 *.tflite
+
+spec/

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,39 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="android" withSubpackages="true" static="true" />
+          <package name="androidx" withSubpackages="true" static="true" />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="junit" withSubpackages="true" static="true" />
+          <package name="net" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/app/src/main/java/com/punyo/nitechvacancyviewer/data/auth/source/UserCredentialsLocalDataSource.kt
+++ b/app/src/main/java/com/punyo/nitechvacancyviewer/data/auth/source/UserCredentialsLocalDataSource.kt
@@ -1,7 +1,6 @@
 package com.punyo.nitechvacancyviewer.data.auth.source
 
 import android.content.Context
-import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
@@ -11,43 +10,52 @@ import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.integration.android.AndroidKeysetManager
+import com.google.crypto.tink.integration.android.AndroidKeystoreKmsClient
 import com.punyo.nitechvacancyviewer.data.auth.model.UserCredentialsDataModel
 import kotlinx.coroutines.flow.first
+import java.io.IOException
 import java.lang.Exception
+import java.security.GeneralSecurityException
+import java.security.ProviderException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 class UserCredentialsLocalDataSource {
     companion object {
-        private const val KEYSTORE_ALIAS = "UserCredentials"
+        internal const val KEYSTORE_ALIAS = "UserCredentials"
+        internal const val PREF_FILE_NAME = "credentials_preference"
+        internal const val DATASTORE_NAME = "credentials"
         private const val KEYSET_NAME = "credentials_keyset"
-        private const val PREF_FILE_NAME = "credentials_preference"
+        private const val MASTER_KEY_URI = "android-keystore://$KEYSTORE_ALIAS"
     }
 
     private val usernamePreference = stringPreferencesKey("username")
-    private val passwordPREFERENCE = stringPreferencesKey("password")
-    private val Context.dataStore by preferencesDataStore(name = "credentials")
-    private lateinit var aead: Aead
+    private val passwordPreference = stringPreferencesKey("password")
+    private val Context.dataStore by preferencesDataStore(name = DATASTORE_NAME)
+    private var aead: Aead? = null
 
     suspend fun loadCredentials(context: Context): UserCredentialsDataModel? {
-        try {
-            val dataStore: DataStore<Preferences> = context.dataStore
-            val userName = dataStore.data.first()[usernamePreference]
-            val password = dataStore.data.first()[passwordPREFERENCE]
-            return if (userName != null && password != null) {
-                decryptCredentials(context, UserCredentialsDataModel(userName, password))
-            } else {
-                null
+        val dataStore: DataStore<Preferences> = context.dataStore
+        val storedCredentials =
+            try {
+                val userName = dataStore.data.first()[usernamePreference]
+                val password = dataStore.data.first()[passwordPreference]
+                if (userName == null || password == null) return null
+                UserCredentialsDataModel(userName, password)
+            } catch (_: NoSuchElementException) {
+                return null
             }
-        } catch (e: NoSuchElementException) {
-            return null
+        return try {
+            decryptCredentials(context, storedCredentials)
         } catch (e: Exception) {
-            Log.e(
-                "UserCredentialsLocalDataSource",
-                "Loading credentials failed: ${e.message}\nClear existing credentials...",
-            )
-            clearCredentials(context)
-            return null
+            when {
+                isRecoverableKeysetFailure(e) -> {
+                    resetKeyset(context)
+                    null
+                }
+
+                else -> throw e
+            }
         }
     }
 
@@ -56,10 +64,23 @@ class UserCredentialsLocalDataSource {
         userCredentials: UserCredentialsDataModel,
     ) {
         val dataStore: DataStore<Preferences> = context.dataStore
-        val encryptedCredentials = encryptCredentials(context, userCredentials)
+        val encryptedCredentials =
+            try {
+                encryptCredentials(context, userCredentials)
+            } catch (e: Exception) {
+                when {
+                    isRecoverableKeysetFailure(e) -> {
+                        // keyset が無い状態から作り直せば master key ごと再生成されるため、1 度だけ再試行する。
+                        resetKeyset(context)
+                        encryptCredentials(context, userCredentials)
+                    }
+
+                    else -> throw e
+                }
+            }
         dataStore.edit { preferences ->
             preferences[usernamePreference] = encryptedCredentials.userName
-            preferences[passwordPREFERENCE] = encryptedCredentials.password
+            preferences[passwordPreference] = encryptedCredentials.password
         }
     }
 
@@ -67,8 +88,33 @@ class UserCredentialsLocalDataSource {
         val dataStore: DataStore<Preferences> = context.dataStore
         dataStore.edit { preferences ->
             preferences.remove(usernamePreference)
-            preferences.remove(passwordPREFERENCE)
+            preferences.remove(passwordPreference)
         }
+    }
+
+    /**
+     * keysetを破棄して初期状態へ戻せば回復できる失敗かどうかを判定する
+     */
+    private fun isRecoverableKeysetFailure(e: Exception): Boolean =
+        e is GeneralSecurityException || e is ProviderException || e is IOException
+
+    /**
+     * Tink の keyset と Android Keystore の master key を破棄し、初期状態へ戻す。
+     *
+     * AndroidKeysetManagerはkeysetが存在する経路ではmaster keyを再生成しないため、
+     * 端末移行等でmaster keyを失った場合はkeysetごと削除して作り直す
+     * */
+    @Suppress("ApplySharedPref")
+    private suspend fun resetKeyset(context: Context) {
+        aead = null
+        // apply()では削除が非同期になるのでcommit()で同期的に削除する
+        context
+            .getSharedPreferences(PREF_FILE_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        AndroidKeystoreKmsClient().deleteKey(MASTER_KEY_URI)
+        clearCredentials(context)
     }
 
     @OptIn(ExperimentalEncodingApi::class)
@@ -76,9 +122,7 @@ class UserCredentialsLocalDataSource {
         context: Context,
         credential: UserCredentialsDataModel,
     ): UserCredentialsDataModel {
-        if (::aead.isInitialized.not()) {
-            initializeAead(context)
-        }
+        val aead = obtainAead(context)
         val encryptedUserName = aead.encrypt(credential.userName.toByteArray(), null)
         val encryptedPassword = aead.encrypt(credential.password.toByteArray(), null)
         return UserCredentialsDataModel(
@@ -92,9 +136,7 @@ class UserCredentialsLocalDataSource {
         context: Context,
         credential: UserCredentialsDataModel,
     ): UserCredentialsDataModel {
-        if (::aead.isInitialized.not()) {
-            initializeAead(context)
-        }
+        val aead = obtainAead(context)
         val decryptedUserName = aead.decrypt(Base64.decode(credential.userName), null)
         val decryptedPassword = aead.decrypt(Base64.decode(credential.password), null)
         return UserCredentialsDataModel(
@@ -103,19 +145,20 @@ class UserCredentialsLocalDataSource {
         )
     }
 
-    private fun initializeAead(context: Context) {
+    private fun obtainAead(context: Context): Aead = aead ?: createAead(context).also { aead = it }
+
+    private fun createAead(context: Context): Aead {
         AeadConfig.register()
-        aead =
-            AndroidKeysetManager
-                .Builder()
-                .withSharedPref(
-                    context,
-                    KEYSET_NAME,
-                    PREF_FILE_NAME,
-                ).withKeyTemplate(KeyTemplates.get("AES256_GCM"))
-                .withMasterKeyUri("android-keystore://$KEYSTORE_ALIAS")
-                .build()
-                .keysetHandle
-                .getPrimitive(Aead::class.java)
+        return AndroidKeysetManager
+            .Builder()
+            .withSharedPref(
+                context,
+                KEYSET_NAME,
+                PREF_FILE_NAME,
+            ).withKeyTemplate(KeyTemplates.get("AES256_GCM"))
+            .withMasterKeyUri(MASTER_KEY_URI)
+            .build()
+            .keysetHandle
+            .getPrimitive(Aead::class.java)
     }
 }

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
+   Android 11 (API level 30) 以下向けの除外ルール。minSdk が 26 のため必要となる。
+   Android 12 以降は data_extraction_rules.xml が使用される。
+
+   除外の理由と path の対応関係は data_extraction_rules.xml のコメントを参照すること。
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude
+        domain="sharedpref"
+        path="credentials_preference.xml" />
+    <exclude
+        domain="sharedpref"
+        path="credentials_preference.xml.bak" />
+    <exclude
+        domain="file"
+        path="datastore/credentials.preferences_pb" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude
+            domain="sharedpref"
+            path="credentials_preference.xml" />
+        <exclude
+            domain="sharedpref"
+            path="credentials_preference.xml.bak" />
+        <exclude
+            domain="file"
+            path="datastore/credentials.preferences_pb" />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude
+            domain="sharedpref"
+            path="credentials_preference.xml" />
+        <exclude
+            domain="sharedpref"
+            path="credentials_preference.xml.bak" />
+        <exclude
+            domain="file"
+            path="datastore/credentials.preferences_pb" />
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
# 概要

端末移行やバックアップ復元によって Android Keystore の master key が失われた状態のとき、`UserCredentialsLocalDataSource` が `java.security.InvalidKeyException` を送出してクラッシュしていた問題を修正する。

原因は、Tink の `AndroidKeysetManager` が SharedPreferences に keyset が残っている経路では master key を再生成しないことである。復元された keyset と失われた master key が食い違ったまま復号・暗号化が行われ、例外に至っていた。そこで、回復可能な失敗を検出した場合は keyset と master key の双方を破棄して初期状態から作り直すようにした。

あわせて、この不整合の発生源そのものを断つため、認証情報の保存先をバックアップおよび端末間移行の対象から除外する設定を追加した。

# 細かな変更点

- `UserCredentialsLocalDataSource` に `resetKeyset` を追加した。SharedPreferences (`credentials_preference`) を `commit()` で同期的に消去し、`AndroidKeystoreKmsClient().deleteKey()` で master key を削除したうえで、保存済みの認証情報も破棄する。master key のエイリアスを削除しないと Tink の `generateKeyIfNotExist` が鍵を作り直さないため、エイリアスの削除まで行っている。
- 回復可否の判定を `isRecoverableKeysetFailure` に切り出し、`GeneralSecurityException` / `ProviderException` / `IOException` のみを回復対象とした。従来の `catch (e: Exception)` による全例外の握りつぶしと `Log.e` を廃し、回復対象外の例外は呼び出し元へ再送出する。
- `saveCredentials` は回復可能な失敗を検出した際に `resetKeyset` を行い、暗号化を 1 度だけ再試行する。`loadCredentials` は復号できた認証情報が存在しない以上リセットして `null` を返す。
- `aead` を `lateinit var` から `Aead?` に変更し、`obtainAead` / `createAead` に分離した。`resetKeyset` でキャッシュを破棄できるようにするためである。
- `backup_rules.xml` と `data_extraction_rules.xml` に除外ルールを定義した。対象は `sharedpref` の `credentials_preference.xml` および `credentials_preference.xml.bak`、`file` の `datastore/credentials.preferences_pb` であり、`cloud-backup` と `device-transfer` の双方に適用する。`backup_rules.xml` は minSdk が 26 であるため Android 11 以下向けに引き続き必要である。
- 保存先を表す `KEYSTORE_ALIAS` / `PREF_FILE_NAME` / `DATASTORE_NAME` を `internal const` へ変更し、DataStore 名のリテラル重複を解消した。master key URI も `MASTER_KEY_URI` として定数化している。
- 誤った命名であった `passwordPREFERENCE` を `passwordPreference` へ改めた。
- `.gitignore` を `.idea/*` の一括除外とホワイトリスト方式へ整理し、`spec/` を追加した。あわせて `.idea/codeStyles/Project.xml` に import の並び順設定を追加した。

# 既存の箇所への影響範囲

- 呼び出し元は `AuthRepositoryImpl` のみである。`loadCredentials` が回復不能な例外を握りつぶさなくなるため、想定外の失敗は従来のように無言で `null` になるのではなく、例外として表面化する。
- バックアップおよび端末間移行の対象から認証情報を除外したため、機種変更後は再ログインが必要になる。復号できない認証情報が復元される従来の挙動よりも意図が明確である。
- `resetKeyset` が動作した場合、保存済みの認証情報は破棄される。`loadCredentials` は `null` を返すため、アプリ側では未ログイン状態として扱われる。
- `.gitignore` の方式変更により、これまで追跡されていなかった `.idea` 配下のファイルの扱いが変わる。ホワイトリストに挙げたもの以外は引き続き無視される。
