### PR TITLE
feat: targetSdkを36に移行

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,11 +11,12 @@ plugins {
 
 android {
     namespace = "com.punyo.nitechvacancyviewer"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         applicationId = "com.punyo.nitechvacancyviewer"
         minSdk = 26
-        targetSdk = 35
+        // TODO: 大画面対応
+        targetSdk = 36
         versionCode = 13
         versionName = "1.6.2"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         minSdk = 26
         // TODO: 大画面対応
         targetSdk = 36
-        versionCode = 13
-        versionName = "1.6.2"
+        versionCode = 14
+        versionName = "1.6.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
# 概要

Android 16 (API level 36) への対応として、`app/build.gradle.kts` の `compileSdk` と `targetSdk` を 35 から 36 へ更新した。

# 細かな変更点

- `compileSdk` を 35 から 36 に変更した。
- `targetSdk` を 35 から 36 に変更した。
- `targetSdk` の指定行に、大画面対応が未着手である旨の TODO コメントを追加した。

# 既存の箇所への影響範囲

`targetSdk` を 36 にすると、Android 16 端末上で以下の挙動変更が適用される。いずれも既存実装で対応済みか、マニフェスト上の追加変更が不要であることを確認した。

- **edge-to-edge の強制**: `windowOptOutEdgeToEdgeEnforcement` による opt-out が無効化されるが、`MainActivity.kt` で既に `enableEdgeToEdge()` を呼び出しており、opt-out 属性も使用していないため影響はない。
- **predictive back の既定有効化**: `Activity.onBackPressed()` は呼ばれなくなるが、本アプリに当該メソッドのオーバーライドは存在しない。`RoomVacancyScreen` や `TopAppBarWithBackArrowComponent` の `onBackPressed` は Compose のコールバック引数であり、システムバックは Navigation Compose 側で処理しているため影響を受けない。
- **大画面での画面向き・リサイズ制限の無視**: smallest width が 600dp 以上の画面で `screenOrientation` や `resizableActivity` が無視されるが、`AndroidManifest.xml` にこれらの指定はないため、マニフェストの変更は不要である。ただしレイアウト自体の大画面最適化は未対応であり、TODO コメントとして残している。

ビルドツールは AGP 8.9.2 を使用しており、`compileSdk = 36` に対応している。ローカルで `./gradlew :app:assembleDebug` が成功することを確認済みである。

確認観点は次のとおりである。

- API 36 環境での起動および画面遷移が正常に行えること。
- システムバックによる画面遷移が従来どおり動作すること。
- sw600dp 以上の端末でレイアウトが大きく崩れないこと (最適化自体は本 PR の対象外)。
